### PR TITLE
Live roi and USBtraffic

### DIFF
--- a/+inst/@QHYccd/QHYccd.m
+++ b/+inst/@QHYccd/QHYccd.m
@@ -65,6 +65,7 @@ classdef QHYccd < obs.camera
     properties(Hidden, SetObservable,GetObservable)
         Color
         BitDepth
+        USBtraffic
         DebugOutput=false; % if set true, library blabber is printed on stderr
         DebugLogLevel=10; % the higher, the more verbose; no idea what each number does
         LastImageSaved=false; % set true by the abstractor when saving the image, reset to false at new exposure
@@ -270,20 +271,29 @@ classdef QHYccd < obs.camera
         
         % ROI - assuming that this is what the SDK calls "Resolution"
         function set.ROI(QC,roi)
+            % ROI is [x1,y1,x2,y2]
             % resolution is [x1,y1,sizex,sizey]
             %  I highly suspect that this setting is very problematic
             %   especially in color mode.
             %  Safe values should be [0,0,physical_size.nx,physical_size.ny]
-            x1=roi(1);
-            y1=roi(2);
-            sx=roi(3)-roi(1)+1;
-            sy=roi(4)-roi(2)+1;
-            
-            % try to clip unreasonable values
-            x1=max(min(x1,QC.physical_size.nx-1),0);
-            y1=max(min(y1,QC.physical_size.ny-1),0);
-            sx=max(min(sx,QC.physical_size.nx-x1),1);
-            sy=max(min(sy,QC.physical_size.ny-y1),1);
+            % NB: according to my experiments with SDK 25.6.16.15, Live mode appears to
+            %     fail with all ROIs which do not end at y2 = physical_size.ny
+            if ~isempty(roi)
+                x1=roi(1);
+                y1=roi(2);
+                sx=roi(3)-roi(1)+1;
+                sy=roi(4)-roi(2)+1;
+                % try to clip unreasonable values
+                x1=max(min(x1,QC.physical_size.nx-1),0);
+                y1=max(min(y1,QC.physical_size.ny-1),0);
+                sx=max(min(sx,QC.physical_size.nx-x1),1);
+                sy=max(min(sy,QC.physical_size.ny-y1),1);
+            else
+                x1=0;
+                y1=0;
+                sx=QC.physical_size.nx;
+                sy=QC.physical_size.ny;
+            end
             
             success=(SetQHYCCDResolution(QC.camhandle,x1,y1,sx,sy)==0);
             if ~success
@@ -293,6 +303,7 @@ classdef QHYccd < obs.camera
 
         % only for recent (>8.2021 versions of the SDK)
          function roi=get.ROI(QC)
+             % ROI is [x1,y1,x2,y2]
              [ret,aX,aY,sX,sY] = GetQHYCCDCurrentROI(QC.camhandle);
              if ret==0
                  roi=[aX,aY,aX+sX-1,aY+sY-1];
@@ -385,6 +396,19 @@ classdef QHYccd < obs.camera
             % check whether err=double(FFFFFFFF)...
             success=(BitDepth==8 | BitDepth==16);
             QC.setLastError(success,'could not get bit depth')
+        end
+
+        function set.USBtraffic(QC,traffic)
+            QC.reportDebug('Setting USB traffic value to %d\n',traffic)
+            success=SetQHYCCDParam(QC.camhandle,inst.qhyccdControl.CONTROL_USBTRAFFIC,traffic);
+            QC.setLastError(success,'could not set USB traffic value')
+        end
+
+        function traffic=get.USBtraffic(QC)
+            traffic=GetQHYCCDParam(QC.camhandle,inst.qhyccdControl.CONTROL_USBTRAFFIC);
+            success=(traffic>=0 & traffic<2e6);
+            % check whether err=double(FFFFFFFF)...
+            QC.setLastError(success,'could not get USB traffic value')
         end
 
         function set.DebugOutput(QC,flag)

--- a/+inst/@QHYccd/QHYccd.m
+++ b/+inst/@QHYccd/QHYccd.m
@@ -304,7 +304,11 @@ classdef QHYccd < obs.camera
         % only for recent (>8.2021 versions of the SDK)
          function roi=get.ROI(QC)
              % ROI is [x1,y1,x2,y2]
-             [ret,aX,aY,sX,sY] = GetQHYCCDCurrentROI(QC.camhandle);
+             try
+                 [ret,aX,aY,sX,sY] = GetQHYCCDCurrentROI(QC.camhandle);
+             catch
+                 ret=-1;
+             end
              if ret==0
                  roi=[aX,aY,aX+sX-1,aY+sY-1];
              else

--- a/+inst/@QHYccd/collectLiveExposure.m
+++ b/+inst/@QHYccd/collectLiveExposure.m
@@ -1,6 +1,8 @@
 function img=collectLiveExposure(QC,varargin)
 % collect a frame from an ongoing live take, but only if we are in Live Mode, if
 %  exposure was started, and time out if waiting for more than X*texp
+% NB: according to my experiments with SDK 25.6.16.15, Live mode appears to
+%     fail with all ROIs which do not end at y2 = physical_size.ny 
  
     % 600msec is for 16bit, USB3, full frame. If there would be a neat
     %  way of understanding ROI, bit mode, color mode, USB speed, without
@@ -8,6 +10,9 @@ function img=collectLiveExposure(QC,varargin)
     % setting up the scenes for the first image requires additional ~2 secs 
     %  plus about two exposures. Thus for long exposures the first image 
     %  may be retrieved only after something like 3*texp!
+    % This is reduced to *one* wasted exposure, thanks to
+    %  SetQHYCCDBurstModePatchNumber(QC.camhandle,32001) (see also comments
+    %  inside .initStreamMode)
     exptime=QC.ExpTime; % read it only once, via GetQHYCCDParam
                         % (beware: could be MAXINT/1e6 if camera went fishing)
     if exptime==(2^32-1)*1e-6

--- a/+inst/@QHYccd/private/initStreamMode.m
+++ b/+inst/@QHYccd/private/initStreamMode.m
@@ -33,6 +33,9 @@ function initStreamMode(QC,newmode)
         tic;
     end
     
+    roi = QC.ROI; % save the current value, to pass it to resetCriticalParameters
+    traffic = QC.USBtraffic;
+    
     if newmode ~= QC.StreamMode || newmode==1 && QC.ExpTime<0.5
         if newmode==1 && QC.ExpTime<0.5
             % the effectivenes of this is dubious, but is the best
@@ -77,5 +80,5 @@ function initStreamMode(QC,newmode)
         %  to redo it before each live sequence, even if we had already
         %  done it earlier and we haven't changed StreamMode. Otherwise,
         %  bad things.
-        QC.resetCriticalParameters
+        QC.resetCriticalParameters(roi,traffic)
     end

--- a/+inst/@QHYccd/private/resetCriticalParameters.m
+++ b/+inst/@QHYccd/private/resetCriticalParameters.m
@@ -1,4 +1,4 @@
-function resetCriticalParameters(QC)
+function resetCriticalParameters(QC,roi,traffic)
 % set again parameters which must be resetted when changing StreamMode
 %  otherwise evil things happens
 % As some of these parameters (e.g color, ROI) have a setter function in 
@@ -6,6 +6,12 @@ function resetCriticalParameters(QC)
 %  to use them. Future handling of different values will probably require
 %  a representation of the last set status in the class itself, with design
 %  complications.
+    arguments
+        QC inst.QHYccd
+        roi = [];
+        traffic = 10;
+    end
+
     QC.Color=false;
     QC.Binning=QC.Binning;
     QC.reportDebug('calling SetQHYCCDResolution\n')
@@ -14,7 +20,8 @@ function resetCriticalParameters(QC)
         QC.reportError('cannot get camera chip size!')
         return
     end
-    SetQHYCCDResolution(QC.camhandle,0,0,QC.physical_size.nx,QC.physical_size.ny);
+%    SetQHYCCDResolution(QC.camhandle,0,0,QC.physical_size.nx,QC.physical_size.ny);
+    QC.ROI=roi;
     QC.reportDebug('after SetQHYCCDResolution call\n')
 %     QC.ROI=[QC.effective_area.x1Eff,QC.effective_area.y1Eff,...
 %         QC.effective_area.x1Eff+QC.effective_area.sxEff,...
@@ -24,9 +31,9 @@ function resetCriticalParameters(QC)
     %  instead changes it to Gain=2000
     QC.Gain=QC.Gain;
     QC.Offset=QC.Offset; % maybe this has to be reset, maybe not
-    % maybe too low USB traffic is at risk od libusb errors -> crashes
+    % maybe too low USB traffic is at risk of libusb errors -> crashes
     QC.reportDebug('calling SetQHYCCDParam USBTRAFFIC & DDR\n')
-    SetQHYCCDParam(QC.camhandle,inst.qhyccdControl.CONTROL_USBTRAFFIC,10);
+    SetQHYCCDParam(QC.camhandle,inst.qhyccdControl.CONTROL_USBTRAFFIC,traffic);
     SetQHYCCDParam(QC.camhandle,inst.qhyccdControl.CONTROL_DDR,1);
     QC.reportDebug('after SetQHYCCDParam USBTRAFFIC & DDR\n')
 


### PR DESCRIPTION
ROI setter and getter (only for newer SDK) sanitized, and added property .USBtraffic.

Minimally tested as working with SDK 25.6.16.15 with a single camera and on past01w with SDK 21.7.16.13 and two cameras. Should be ok for production, but better to check a bit more carefully.